### PR TITLE
Subjet reconstruction in large-R jet's center-of-mass frame

### DIFF
--- a/JetSubStructureUtils/JetSubStructureUtils/SubjetFinder.h
+++ b/JetSubStructureUtils/JetSubStructureUtils/SubjetFinder.h
@@ -18,8 +18,7 @@ namespace JetSubStructureUtils {
       float m_jetrad;
       float m_ptmin;
       int m_exclusivenjets; 
-      
-      bool m_doCOM; // -- JY --
+      bool m_doCOM;
   };
 }
 

--- a/JetSubStructureUtils/JetSubStructureUtils/SubjetFinder.h
+++ b/JetSubStructureUtils/JetSubStructureUtils/SubjetFinder.h
@@ -17,7 +17,9 @@ namespace JetSubStructureUtils {
       fastjet::JetAlgorithm m_fj_jetalg;
       float m_jetrad;
       float m_ptmin;
-      int m_exclusivenjets;
+      int m_exclusivenjets; 
+      
+      bool m_doCOM; // -- JY --
   };
 }
 

--- a/JetSubStructureUtils/Root/SubjetFinder.cxx
+++ b/JetSubStructureUtils/Root/SubjetFinder.cxx
@@ -3,13 +3,13 @@
 #include "fastjet/JetDefinition.hh"
 #include <iostream>
 
-#include "fastjet/EECambridgePlugin.hh" // -- JY: for CoM subjet --
+#include "fastjet/EECambridgePlugin.hh"
 
 using namespace std;
 using namespace JetSubStructureUtils;
 
 SubjetFinder::SubjetFinder(fastjet::JetAlgorithm fj_jetalg, float jet_radius, float pt_min, int exclusive_njets) :
-  m_fj_jetalg(fj_jetalg), m_jetrad(jet_radius), m_ptmin(pt_min), m_exclusivenjets(exclusive_njets),m_doCOM(false) // -- JY: for CoM option --
+  m_fj_jetalg(fj_jetalg), m_jetrad(jet_radius), m_ptmin(pt_min), m_exclusivenjets(exclusive_njets),m_doCOM(false)
 {
 }
 
@@ -23,7 +23,7 @@ vector<fastjet::PseudoJet> SubjetFinder::result(const fastjet::PseudoJet &jet) c
   }
 
 
-  // -- JY: adding option of CoM --
+  
   fastjet::ClusterSequence *clust_seq = NULL;
   if (!m_doCOM){ 
     fastjet::JetDefinition jet_def = fastjet::JetDefinition(m_fj_jetalg, m_jetrad, fastjet::E_scheme, fastjet::Best);


### PR DESCRIPTION
Adding options to allow subjets reconstruction in a large-R jet's center-of-mass (CoM) frame:
1) constituents are boosted into CoM frame.
2) run fast-jet with modified EECambridge algorithm.
3) subjets are boosted back to lab-frame.