### PR TITLE
BoostedXbbTag: Version used for ICHEP 2016 result

### DIFF
--- a/JetSubStructureUtils/JetSubStructureUtils/BoostedXbbTag.h
+++ b/JetSubStructureUtils/JetSubStructureUtils/BoostedXbbTag.h
@@ -24,9 +24,9 @@ namespace JetSubStructureUtils {
       // standard tool constructor
       BoostedXbbTag(std::string working_point           = "medium",
 #ifdef ROOTCORE
-                    std::string recommendations_file    = "$ROOTCOREBIN/data/JetSubStructureUtils/config_13TeV_Htagging_MC15_Prerecommendations_20150812.dat",
+                    std::string recommendations_file    = "$ROOTCOREBIN/data/JetSubStructureUtils/config_13TeV_Htagging_MC15c_77WP_20160522.dat",
 #else
-                    std::string recommendations_file    = "JetSubStructureUtils/data/config_13TeV_Htagging_MC15_Prerecommendations_20150812.dat",
+                    std::string recommendations_file    = "JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_77WP_20160522.dat",
 #endif
                     std::string boson_type              = "Higgs",
                     std::string algorithm_name          = "AK10LCTRIMF5R20",
@@ -68,6 +68,7 @@ namespace JetSubStructureUtils {
            m_verbose;
 
       float m_bTagCut,
+            m_bTagCutCharm,
             m_massMin,
             m_massMax;
       std::vector<float> m_D2_params;

--- a/JetSubStructureUtils/Root/BoostedXbbTag.cxx
+++ b/JetSubStructureUtils/Root/BoostedXbbTag.cxx
@@ -53,6 +53,7 @@ BoostedXbbTag::BoostedXbbTag( std::string working_point,
   m_debug(debug),
   m_verbose(verbose),
   m_bTagCut(FLT_MIN),
+  m_bTagCutCharm(FLT_MIN),
   m_massMin(FLT_MIN),
   m_massMax(FLT_MAX),
   m_D2_params(5, FLT_MIN),
@@ -90,9 +91,9 @@ BoostedXbbTag::BoostedXbbTag( std::string working_point,
     m_bad_configuration |= true;
   }
 
-  std::set<std::string> validWorkingPoints = {"tight", "medium", "loose", "veryloose"};
+  std::set<std::string> validWorkingPoints = {"tight", "medium", "loose", "veryloose", "single", "single_loose", "single_medium"};
   if( validWorkingPoints.find(m_working_point) == validWorkingPoints.end()){
-    printf("<%s>: Unknown working point requested.\r\n\tExpected: veryloose, loose, medium, tight\r\n\tGiven:    %s\r\n", APP_NAME, m_working_point.c_str());
+    printf("<%s>: Unknown working point requested.\r\n\tExpected: single, single_loose, single_medium, veryloose, loose, medium, tight\r\n\tGiven:    %s\r\n", APP_NAME, m_working_point.c_str());
     m_bad_configuration |= true;
   } else {
     if(m_verbose) printf("<%s>: Valid working point requested.\r\n", APP_NAME);
@@ -144,7 +145,7 @@ BoostedXbbTag::BoostedXbbTag( std::string working_point,
         std::istringstream ss(line);
         /* lineDetails is an array of the splits */
         std::vector<std::string> lineDetails{std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{}};
-        if(lineDetails.size() != 13) continue;
+        if(lineDetails.size() != 14) continue;
 
         if(m_verbose) printf("<%s>: Reading in line\r\n\t'%s'\r\n", APP_NAME, line.c_str());
         if(lineDetails[0] != m_boson_type) continue;
@@ -153,11 +154,12 @@ BoostedXbbTag::BoostedXbbTag( std::string working_point,
         if(std::stoi(lineDetails[3]) != m_num_bTags) continue;
 
         m_bTagCut             = std::stof(lineDetails[4]);
-        m_massMin             = std::stof(lineDetails[5]);
-        m_massMax             = std::stof(lineDetails[6]);
+        m_bTagCutCharm        = std::stof(lineDetails[5]);
+        m_massMin             = std::stof(lineDetails[6]);
+        m_massMax             = std::stof(lineDetails[7]);
         for(int i=0; i < 5; i++)
-          m_D2_params[i]      = std::stof(lineDetails[i+7]);
-        m_D2_cut_direction    = lineDetails[12];
+          m_D2_params[i]      = std::stof(lineDetails[i+8]);
+        m_D2_cut_direction    = lineDetails[13];
 
         if(m_verbose) printf("<%s>: Found the configuration! We're done reading the file.\r\n", APP_NAME);
         found_configuration = true;
@@ -353,10 +355,11 @@ int BoostedXbbTag::result(const xAOD::Jet& jet, std::string algorithm_name, cons
     if(m_verbose) printf("<%s>: Jet does not pass basic kinematic selection. pT > 250 GeV, |eta| < 2.0\r\n\tJet Pt: %0.6f GeV\r\n\tJet |eta|: %0.6f\r\n", APP_NAME, jet.pt()/1.e3, std::fabs(jet.eta()));
     return -5;
   }
-  if(jet.pt()/1.e3 > 2000.0){
-    printf("<%s>: Warning, jet has pT > 2 TeV!\r\nJet Pt: %0.6f GeV", APP_NAME, jet.pt()/1.e3);
-    return -5;
-  }
+  // upper pT cut from 2015 not needed anymore because uncertainties are now available
+  //if(jet.pt()/1.e3 > 2000.0){
+  //  printf("<%s>: Warning, jet has pT > 2 TeV!\r\nJet Pt: %0.6f GeV", APP_NAME, jet.pt()/1.e3);
+  //  return -5;
+  //}
 
   // make sure we are using the right kind of jet
   if(algorithm_name != m_algorithm_name){
@@ -367,7 +370,9 @@ int BoostedXbbTag::result(const xAOD::Jet& jet, std::string algorithm_name, cons
   /* Steps:
       1. Get all AntiKt2TrackJets asssociated with the ungroomed jet
       2. B-tag the two leading track-jets
-      3. If both track-jets are b-tagged, match the muon (if any) to these b-tagged track-jets
+        - if double b-tagging, require that both track-jets are b-tagged
+        - if single b-tagging, and there is more than one track-jet, take the highest MV2 of the leading two jets
+      3. Match the muon (if any) to these b-tagged track-jets
         - if more than 1 muon matches a track jet (within the radius of the track jet), only use the muon closest in DR
       4. Correct the fat-jet mass by putting the matched muon back (if there is a matched muon)
       5. Set a cut on the corrected fat jet mass
@@ -391,22 +396,28 @@ int BoostedXbbTag::result(const xAOD::Jet& jet, std::string algorithm_name, cons
     if(problemWithParent && m_debug) printf("Parent decoration does not exist. ");
     if(!parentEL.isValid() && m_debug) printf("Parent link is not valid. ");
     if(m_debug) printf("\r\n");
-    return -2; // do not fallback
-    /*
-    if(m_debug) printf("Get track jets from groomed jet.\r\n");
-    if(!jet.getAssociatedObjects<xAOD::Jet>("GhostAntiKt2TrackJet", associated_trackJets)){
-      if(m_verbose) printf("<%s>: No associated track jets found on jet.\r\n", APP_NAME);
-      return -2;
-    }
-    if(m_verbose) printf("<%s>: Got track jets from groomed jet.\r\n", APP_NAME);
-    */
+    return -2; // do not fallback -- comment out to enable fallback
+    //// fallback here
+    //if(m_debug) printf("Get track jets from groomed jet.\r\n");
+    //if(!jet.getAssociatedObjects<xAOD::Jet>("GhostAntiKt2TrackJet", associated_trackJets)){
+    //  if(m_verbose) printf("<%s>: No associated track jets found on jet.\r\n", APP_NAME);
+    //  return -2;
+    //}
+    //else if(m_verbose) printf("<%s>: Got track jets from groomed jet.\r\n", APP_NAME);
   } else {
     const xAOD::Jet* parentJet = *parentEL;
     if(!parentJet->getAssociatedObjects<xAOD::Jet>("GhostAntiKt2TrackJet", associated_trackJets)){
       if(m_verbose) printf("<%s>: No associated track jets found on parent jet.\r\n", APP_NAME);
-      return -2;
+      return -2; // do not fallback -- comment out to enable fallback
+      //// fallback here
+      //if(m_debug) printf("Get track jets from groomed jet.\r\n");
+      //if(!jet.getAssociatedObjects<xAOD::Jet>("GhostAntiKt2TrackJet", associated_trackJets)){
+      //  if(m_verbose) printf("<%s>: No associated track jets found on jet.\r\n", APP_NAME);
+      //  return -2;
+      //}
+      //else if(m_verbose) printf("<%s>: Got track jets from groomed jet.\r\n", APP_NAME);
     }
-    if(m_verbose) printf("<%s>: Got track jets from parent jet.\r\n", APP_NAME);
+    else if(m_verbose) printf("<%s>: Got track jets from parent jet.\r\n", APP_NAME);
   }
 
   // decorate all trackjets by default
@@ -418,21 +429,52 @@ int BoostedXbbTag::result(const xAOD::Jet& jet, std::string algorithm_name, cons
     std::remove_if(associated_trackJets.begin(), associated_trackJets.end(),  [this](const xAOD::Jet* jet) -> bool { return (jet->pt()/1.e3 < 10.0 || fabs(jet->eta()) > 2.5 || jet->numConstituents() < 2); }),
     associated_trackJets.end());
   if(associated_trackJets.size() < 2){
-    if(m_verbose) printf("<%s>: We need at least two associated track jets.\r\n", APP_NAME);
-    return -2;
+    if(m_working_point.find("single") == std::string::npos){
+      if(m_verbose) printf("<%s>: We need at least two associated track jets for working point %s.\r\n", APP_NAME, m_working_point.c_str());
+      return -2;
+    }
+    else if(associated_trackJets.size() < 1){
+      if(m_verbose) printf("<%s>: We need at least one associated track jet for working point %s.\r\n", APP_NAME, m_working_point.c_str());
+      return -2;
+    }
   }
 
   // Step 2
   std::sort(associated_trackJets.begin(), associated_trackJets.end(), [](const xAOD::IParticle* lhs, const xAOD::IParticle* rhs) -> bool { return (lhs->pt() > rhs->pt()); });
   int num_bTags(0);
-  for(int i=0; i<2; i++){
+  int num_trackJets_toLookAt = std::min((int)associated_trackJets.size(), 2);
+  for(int i = 0; i < num_trackJets_toLookAt; i++){
     auto& trackJet = associated_trackJets.at(i);
-    double mv2c20(FLT_MIN);
-    if(!trackJet->btagging()->MVx_discriminant("MV2c20", mv2c20)){
-      if(m_verbose) printf("<%s>: Could not retrieve the MV2c20 discriminant.\r\n", APP_NAME);
+
+    // MV2c10
+    double mv2c10(FLT_MIN);
+    if(!trackJet->btagging()->MVx_discriminant("MV2c10", mv2c10)){
+      if(m_verbose) printf("<%s>: Could not retrieve the MV2c10 discriminant.\r\n", APP_NAME);
       return -9;
     }
-    int isBTagged = static_cast<int>(mv2c20 > m_bTagCut);
+    int isBTagged = static_cast<int>(mv2c10 > m_bTagCut);
+
+//    // MV2c20
+//    double mv2c20(FLT_MIN);
+//    if(!trackJet->btagging()->MVx_discriminant("MV2c20", mv2c20)){
+//      if(m_verbose) printf("<%s>: Could not retrieve the MV2c20 discriminant.\r\n", APP_NAME);
+//      return -9;
+//    }
+//    int isBTagged = static_cast<int>(mv2c20 > m_bTagCut);
+
+//    // 2D b-tagging
+//    double mv2c00(FLT_MIN);
+//    double mv2c100(FLT_MIN);
+//    if(!trackJet->btagging()->MVx_discriminant("MV2c00", mv2c00)){
+//      if(m_verbose) printf("<%s>: Could not retrieve the MV2c00 discriminant.\r\n", APP_NAME);
+//      return -9;
+//    }
+//    if(!trackJet->btagging()->MVx_discriminant("MV2c100", mv2c100)){
+//      if(m_verbose) printf("<%s>: Could not retrieve the MV2c100 discriminant.\r\n", APP_NAME);
+//      return -9;
+//    }
+//    int isBTagged = static_cast<int>(mv2c00 > m_bTagCut && mv2c100 > m_bTagCutCharm);
+
     isB(*trackJet) = isBTagged;
     num_bTags += isBTagged;
   }
@@ -447,13 +489,15 @@ int BoostedXbbTag::result(const xAOD::Jet& jet, std::string algorithm_name, cons
   std::vector<const xAOD::Muon*> matched_muons;
   // first select the muons: Combined, Medium, pT > 10 GeV, |eta| < 2.5
   std::vector<const xAOD::Muon*> preselected_muons(muons->size(), nullptr);
+  // [Next line: selection for muon matching. IF PROBLEMS with getQuality, disable muon matching temporarily by using the second line below instead]
   auto it = std::copy_if(muons->begin(), muons->end(), preselected_muons.begin(), [this](const xAOD::Muon* muon) -> bool { return (muon->pt()/1.e3 > 10.0 && m_muonSelectionTool->getQuality(*muon) <= xAOD::Muon::Medium && fabs(muon->eta()) < 2.5); });
+  //auto it = std::copy_if(muons->begin(), muons->end(), preselected_muons.begin(), [this](const xAOD::Muon* muon) -> bool { return false; });
   preselected_muons.resize(std::distance(preselected_muons.begin(), it)); // shrink container to new size
   if(preselected_muons.size() == 0){
     if(m_verbose) printf("<%s>: There are no muons that passed the kinematic preselection.\r\n", APP_NAME);
     //return -3;
   } else {
-    for(int i=0; i<2; i++){
+    for(int i = 0; i < num_trackJets_toLookAt; i++){
       auto& trackJet = associated_trackJets.at(i);
       // only match muon to b-tagged track jets
       if(isB(*trackJet) == 0) continue;
@@ -545,10 +589,12 @@ std::vector<const xAOD::Jet*> BoostedXbbTag::get_bTagged_trackJets(const xAOD::J
   std::vector<const xAOD::Jet*> associated_trackJets;
   // get the track jets from the parent
   (*parent(jet))->getAssociatedObjects<xAOD::Jet>("GhostAntiKt2TrackJet", associated_trackJets);
+  //// IF PROBLEMS with association to ungroomed parent, comment out to get track jets from trimmed jet
+  //jet.getAssociatedObjects<xAOD::Jet>("GhostAntiKt2TrackJet", associated_trackJets);
   std::vector<const xAOD::Jet*> bTagged_trackJets;
-  for(const auto& jet: associated_trackJets){
-    if(isB(*jet) == 0) continue;
-    bTagged_trackJets.push_back(jet);
+  for(const auto& trackJet: associated_trackJets){
+    if(isB(*trackJet) == 0) continue;
+    bTagged_trackJets.push_back(trackJet);
   }
   return bTagged_trackJets;
 }

--- a/JetSubStructureUtils/data/config_13TeV_Htagging_MC15b_20150925.dat
+++ b/JetSubStructureUtils/data/config_13TeV_Htagging_MC15b_20150925.dat
@@ -1,0 +1,20 @@
+﻿############################################################################################################################################################
+#ERASE THESE LINES (JUST FOR REFERENCE)
+#1. Veryloose: 	No mass selection, 2 b-tagging (MV2c20 77% track jets R=0.2)
+#1. Loose: 	90% mass window, 2 b-tagging (MV2c20 70% track jets R=0.2)
+#2. Medium: 	68% mass window, 2 b-tagging (MV2c20 70% track jets R=0.2)
+#3. Tight:	68% mass window, 2 b-tagging (MV2c20 70% track jets R=0.2), D2 pT dependent cut (4th degree polynomial fit)
+#Developers working points will be added in a next version of the config file
+#
+#BOSON	WP	  JET ALGORITHM		#bjets	B-TAG	M_min	M_max	D2_a0		D2_a1		D2_a2		D2_a3		D2_a4		Sense of the cut	############################################################################################################################################################
+
+Higgs	veryloose AK10LCTRIMF5R20	2	-0.6134	0.0	7000.	0		0		0		0		0		NONE
+Higgs	loose	  AK10LCTRIMF5R20	2	-0.3098	76.0	146.0	0		0		0		0		0		NONE
+Higgs	medium 	  AK10LCTRIMF5R20	2	-0.3098	93.0	134.0  	0		0		0		0		0		NONE
+Higgs	tight 	  AK10LCTRIMF5R20	2	-0.3098	93.0	134.0  	11.3684217088  	-0.0834101931325	0.000244968552399	-3.09799473883e-07	1.44703493877e-10	RIGHT
+
+#Higgs	dbtag60	  AK10LCTRIMF5R20	2	 0.1899	0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag70	  AK10LCTRIMF5R20	2	-0.3098	0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag77	  AK10LCTRIMF5R20	2	-0.6134	0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag85	  AK10LCTRIMF5R20	2	-0.8433	0.0	7000.	0		0		0		0		0		NONE
+

--- a/JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_70WP_20160522.dat
+++ b/JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_70WP_20160522.dat
@@ -1,0 +1,29 @@
+﻿############################################################################################################################################################
+#ERASE THESE LINES (JUST FOR REFERENCE)
+#Working points considered
+#   B-tagging is MV2c10 70% track jets R=0.2
+# Single:        No mass cut,     1 b-tag
+# Single loose:  90% mass window, 1 b-tag
+# Single medium: 68% mass window, 1 b-tag
+# Veryloose:     No mass cut,     2 b-tag
+# Loose:         90% mass window, 2 b-tag
+# Medium:        68% mass window, 2 b-tag
+# Tight:         68% mass window, 2 b-tag, D2 pT dependent cut (4th degree polynomial fit)  <==  SUBSTRUCTURE NEEDS UPDATING
+#
+#BOSON	WP	  JET ALGORITHM		#bjets	B-TAG	 B-TAG-CHARM	M_min	M_max	D2_a0		D2_a1		D2_a2		D2_a3		D2_a4		Sense of the cut
+
+Higgs	single        AK10LCTRIMF5R20	1	 0.6455	 -1.		0.0	7000.	0		0		0		0		0		NONE
+Higgs	single_loose  AK10LCTRIMF5R20	1	 0.6455	 -1.		76.0	146.0	0		0		0		0		0		NONE
+Higgs	single_medium AK10LCTRIMF5R20	1	 0.6455	 -1.		93.0	134.0	0		0		0		0		0		NONE
+Higgs	veryloose AK10LCTRIMF5R20	2	 0.6455	 -1.		0.0	7000.	0		0		0		0		0		NONE
+Higgs	loose     AK10LCTRIMF5R20	2	 0.6455	 -1.		76.0	146.0	0		0		0		0		0		NONE
+Higgs	medium    AK10LCTRIMF5R20	2	 0.6455	 -1.		93.0	134.0  	0		0		0		0		0		NONE
+Higgs	tight     AK10LCTRIMF5R20	2	 0.6455	 -1.		93.0	134.0  	11.3684217088  	-0.0834101931325	0.000244968552399	-3.09799473883e-07	1.44703493877e-10	RIGHT
+
+#Higgs	dbtag30	  AK10LCTRIMF5R20	2	 0.9951	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag50	  AK10LCTRIMF5R20	2	 0.9452	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag60	  AK10LCTRIMF5R20	2	 0.8529	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag70	  AK10LCTRIMF5R20	2	 0.6455	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag77	  AK10LCTRIMF5R20	2	 0.3706	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag85	  AK10LCTRIMF5R20	2	-0.1416	 -1.		0.0	7000.	0		0		0		0		0		NONE
+

--- a/JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_77WP_20160522.dat
+++ b/JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_77WP_20160522.dat
@@ -1,0 +1,29 @@
+﻿############################################################################################################################################################
+#ERASE THESE LINES (JUST FOR REFERENCE)
+#Working points considered
+#   B-tagging is MV2c10 77% track jets R=0.2
+# Single:        No mass cut,     1 b-tag
+# Single loose:  90% mass window, 1 b-tag
+# Single medium: 68% mass window, 1 b-tag
+# Veryloose:     No mass cut,     2 b-tag
+# Loose:         90% mass window, 2 b-tag
+# Medium:        68% mass window, 2 b-tag
+# Tight:         68% mass window, 2 b-tag, D2 pT dependent cut (4th degree polynomial fit)  <==  SUBSTRUCTURE NEEDS UPDATING
+#
+#BOSON	WP	  JET ALGORITHM		#bjets	B-TAG	 B-TAG-CHARM	M_min	M_max	D2_a0		D2_a1		D2_a2		D2_a3		D2_a4		Sense of the cut
+
+Higgs	single        AK10LCTRIMF5R20	1	 0.3706	 -1.		0.0	7000.	0		0		0		0		0		NONE
+Higgs	single_loose  AK10LCTRIMF5R20	1	 0.3706	 -1.		76.0	146.0	0		0		0		0		0		NONE
+Higgs	single_medium AK10LCTRIMF5R20	1	 0.3706	 -1.		93.0	134.0	0		0		0		0		0		NONE
+Higgs	veryloose AK10LCTRIMF5R20	2	 0.3706	 -1.		0.0	7000.	0		0		0		0		0		NONE
+Higgs	loose     AK10LCTRIMF5R20	2	 0.3706	 -1.		76.0	146.0	0		0		0		0		0		NONE
+Higgs	medium    AK10LCTRIMF5R20	2	 0.3706	 -1.		93.0	134.0  	0		0		0		0		0		NONE
+Higgs	tight     AK10LCTRIMF5R20	2	 0.3706	 -1.		93.0	134.0  	11.3684217088  	-0.0834101931325	0.000244968552399	-3.09799473883e-07	1.44703493877e-10	RIGHT
+
+#Higgs	dbtag30	  AK10LCTRIMF5R20	2	 0.9951	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag50	  AK10LCTRIMF5R20	2	 0.9452	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag60	  AK10LCTRIMF5R20	2	 0.8529	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag70	  AK10LCTRIMF5R20	2	 0.6455	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag77	  AK10LCTRIMF5R20	2	 0.3706	 -1.		0.0	7000.	0		0		0		0		0		NONE
+#Higgs	dbtag85	  AK10LCTRIMF5R20	2	-0.1416	 -1.		0.0	7000.	0		0		0		0		0		NONE
+

--- a/JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_77WP_2D_20160615.dat
+++ b/JetSubStructureUtils/data/config_13TeV_Htagging_MC15c_77WP_2D_20160615.dat
@@ -1,0 +1,21 @@
+﻿############################################################################################################################################################
+#ERASE THESE LINES (JUST FOR REFERENCE)
+#Working points considered
+#   B-tagging is MV2c00_MV2c100 77% track jets R=0.2
+# Single:        No mass cut,     1 b-tag
+# Single loose:  90% mass window, 1 b-tag
+# Single medium: 68% mass window, 1 b-tag
+# Veryloose:     No mass cut,     2 b-tag
+# Loose:         90% mass window, 2 b-tag
+# Medium:        68% mass window, 2 b-tag
+# Tight:         68% mass window, 2 b-tag, D2 pT dependent cut (4th degree polynomial fit)  <==  SUBSTRUCTURE NEEDS UPDATING
+#
+#BOSON	WP	        JET ALGORITHM	#bjets	B-TAG	B-TAG-CHARM	M_min	M_max	D2_a0		D2_a1		D2_a2		D2_a3		D2_a4		Sense of the cut
+
+Higgs	single          AK10LCTRIMF5R20	1	 0.671	-0.737		0.0	7000.	0		0		0		0		0		NONE
+Higgs	single_loose	AK10LCTRIMF5R20	1	 0.671	-0.737		76.0	146.0	0		0		0		0		0		NONE
+Higgs	single_medium	AK10LCTRIMF5R20	1	 0.671	-0.737		93.0	134.0	0		0		0		0		0		NONE
+Higgs	veryloose	AK10LCTRIMF5R20	2	 0.671	-0.737		0.0	7000.	0		0		0		0		0		NONE
+Higgs	loose           AK10LCTRIMF5R20	2	 0.671	-0.737		76.0	146.0	0		0		0		0		0		NONE
+Higgs	medium          AK10LCTRIMF5R20	2	 0.671	-0.737		93.0	134.0  	0		0		0		0		0		NONE
+Higgs	tight           AK10LCTRIMF5R20	2	 0.671	-0.737		93.0	134.0  	11.3684217088  	-0.0834101931325	0.000244968552399	-3.09799473883e-07	1.44703493877e-10	RIGHT


### PR DESCRIPTION
- new single b-tagging working points
- now using MV2c10
- updated recommendations data
- added 2D b-tagging functionality: we didn't end up using it but now it is there.  It does require one more column in the data files, so breaks compatibility with older ones
- removed pT < 2 TeV cut
- fixed fallback option to match track-jets to groomed large-R jets (was useful when the association to the ungroomed parent was broken) --> disabled in this version
- option to disable muon matching, also motivated by a former problem in the ntuples and commented out in this version
